### PR TITLE
Fix without/dissoc

### DIFF
--- a/src/robertluo/fun_map/core.clj
+++ b/src/robertluo/fun_map/core.clj
@@ -75,7 +75,7 @@
       (delegate-map (.empty m)))
 
     (without [k]
-      (delegate-map (.dissoc m k)))
+      (delegate-map (.without m k)))
 
     (count []
       (.count m))

--- a/test/robertluo/fun_map_test.clj
+++ b/test/robertluo/fun_map_test.clj
@@ -28,6 +28,9 @@
            (merge (fun-map {:b (fnk [a] (inc a))})
                   {:a 5}))))
 
+  (testing "dissoc"
+    (is (= {:a 3} (dissoc (fun-map {:a 3 :b 4}) :b))))
+
   (testing "meta data support"
     (is (= {:msg "ok"} (meta (with-meta (fun-map {:a 3}) {:msg "ok"}))))))
 


### PR DESCRIPTION
Cool lib.

Also, here is an idea: allow multiple keys to be specified as a single destructuring vector key.

```clojure
(let [m (fun-map {[a b] (fnk [] [1 2])
                  :c    (fnk [a b] (+ a b))})]
  (:c m)) ; => 3
```

If you find this interesting, you may find https://tristefigure.github.io/shuriken/shuriken.destructure.html useful in order to parse destructuring vectors.