### PR TITLE
clj-kondo can not pickup `fnk` if does not refer to `fw`

### DIFF
--- a/resources/clj-kondo.exports/robertluo/fun-map/clj_kondo/fun_map.clj
+++ b/resources/clj-kondo.exports/robertluo/fun-map/clj_kondo/fun_map.clj
@@ -22,7 +22,7 @@
   (let [[arg-vec & body] (-> node :children rest)
         new-node (api/list-node
                   (list*
-                   (api/token-node 'fw)
+                   (api/token-node 'robertluo.fun-map/fw)
                    (api/map-node [(api/keyword-node :keys) arg-vec])
                    body))]
     {:node new-node}))

--- a/test/robertluo/fun_map_test.cljc
+++ b/test/robertluo/fun_map_test.cljc
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    #?(:clj
-      [robertluo.fun-map :refer [fun-map? fnk fun-map closeable life-cycle-map touch halt! fw lookup halt!]]
+      [robertluo.fun-map :refer [fun-map? fnk fw fun-map closeable life-cycle-map touch halt! lookup halt!]]
       :cljs
       [robertluo.fun-map 
        :as fm


### PR DESCRIPTION
Fixes #44