### PR TITLE
Fix reflection warning

### DIFF
--- a/src/robertluo/fun_map/core.cljc
+++ b/src/robertluo/fun_map/core.cljc
@@ -3,7 +3,8 @@
   (:import #?(:clj [clojure.lang
                     IMapEntry
                     IPersistentMap
-                    ITransientMap])))
+                    ITransientMap
+                    ATransientMap])))
 
 #?(:clj
 ;;Marker iterface for a funmap
@@ -17,7 +18,7 @@
 
 ;;Support transient
 #?(:clj
-   (deftype TransientDelegatedMap [^ITransientMap tm fn-entry]
+   (deftype TransientDelegatedMap [^ATransientMap tm fn-entry]
      ITransientMap
      (conj [_ v] (TransientDelegatedMap. (.conj tm v) fn-entry))
      (persistent [_] (->DelegatedMap (persistent! tm) fn-entry))

--- a/src/robertluo/fun_map/core.cljc
+++ b/src/robertluo/fun_map/core.cljc
@@ -179,8 +179,8 @@
         (fn-entry this (-find m k))))
      
      IFn
-     (invoke [this k] (-lookup this k))
-     (invoke [this k not-found] (-lookup this k not-found))
+     (-invoke [this k] (-lookup this k))
+     (-invoke [this k not-found] (-lookup this k not-found))
 
      ILookup
      (-lookup


### PR DESCRIPTION
```clojure
(deftype TransientDelegatedMap [^ITransientMap tm fn-entry]
```

becomes

```clojure
(deftype TransientDelegatedMap [^ATransientMap tm fn-entry]
```

this is to fix warnings about `.entryAt` and `.containsKey`, defined in clojure lang.ITransientMap2. `ATransientMap` implements both `ITransientMap` and `ITransientMap2`

I also fixed a cljs warning: `Bad method signature in protocol implementation, IFn does not declare method called invoke`

```clojure
IFn
 (invoke [this k] (-lookup this k))
 (invoke [this k not-found] (-lookup this k not-found))
  ```

becomes

```clojure
IFn
 (-invoke [this k] (-lookup this k))
 (-invoke [this k not-found] (-lookup this k not-found))
  ```
  
  
  Test results:
  
  ```
  ➜  fun-map git:(master) clj -M:dev:test
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Loading namespaces:  (robertluo.fun-map.util robertluo.fun-map.core robertluo.fun-map.wrapper robertluo.fun-map.helper robertluo.fun-map)
Test namespaces:  (:unit)
Instrumented robertluo.fun-map.util
Instrumented robertluo.fun-map.core
Instrumented robertluo.fun-map.wrapper
Instrumented robertluo.fun-map.helper
Instrumented robertluo.fun-map
Instrumented 5 namespaces in 1,0 seconds.
[(.................................)(...........)(..)]
18 tests, 46 assertions, 0 failures.
Ran tests.
Writing HTML report to: ~/Documents/Code/Clojure/GitHub/fun-map/target/coverage/index.html
Writing codecov.io report to: ~/Documents/Code/Clojure/GitHub/fun-map/target/coverage/codecov.json

|---------------------------+---------+---------|
|                 Namespace | % Forms | % Lines |
|---------------------------+---------+---------|
|         robertluo.fun-map |   92,73 |   97,87 |
|    robertluo.fun-map.core |   71,15 |   68,49 |
|  robertluo.fun-map.helper |   77,49 |   88,64 |
|    robertluo.fun-map.util |   86,67 |   85,71 |
| robertluo.fun-map.wrapper |   79,91 |   82,50 |
|---------------------------+---------+---------|
|                 ALL FILES |   80,73 |   82,46 |
|---------------------------+---------+---------|
➜  fun-map git:(master) clj -M:cljs-test

Testing robertluo.fun-map.core-test

Testing robertluo.fun-map.wrapper-test

Testing robertluo.fun-map-test

Ran 16 tests containing 45 assertions.
0 failures, 0 errors.
➜  fun-map git:(master)
 ```